### PR TITLE
Internationalization

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -1,5 +1,9 @@
 #textdomain wesnoth-XP_Modification
 
+[textdomain]
+    name="wesnoth-XP_Modification"
+    path="data/add-ons/XP_Modification/translations"
+[/textdomain]
 {~add-ons/XP_Modification/macros/xp.cfg}
 {~add-ons/XP_Modification/mods/xp_mod.cfg}
 {~add-ons/XP_Modification/mods/xp_mod_beta.cfg}

--- a/macros/xp.cfg
+++ b/macros/xp.cfg
@@ -1,5 +1,8 @@
 #textdomain wesnoth-XP_Modification
 
+#define XP_MOD_VERSION
+2.4.4#enddef
+
 #define XP_MOD_DRAIN
     [has_attack]
 		special_type=drains

--- a/mods/xp_mod.cfg
+++ b/mods/xp_mod.cfg
@@ -1,9 +1,11 @@
+#textdomain wesnoth-XP_Modification
+
 [modification]
     id=Rav_XP_Mod
     name=_"XP Mod"
     description=_"Spend XP to upgrade units damage/strikes/health/movement.
 
-version 2.4.4 by Ravana - based on work by vn971, Dovolente, itota and Nosmos
+version "+{XP_MOD_VERSION}+_" by Ravana - based on work by vn971, Dovolente, itota and Nosmos
 
 Units with drain ability have higher upgrade cost"
     require_modification=no
@@ -92,6 +94,7 @@ Units with drain ability have higher upgrade cost"
         [lua]
             code=<<
 local T = wml.tag
+local _ = wesnoth.textdomain "wesnoth-XP_Modification"
 
 function wesnoth.wml_actions.xp_mod(cfg)
 
@@ -105,8 +108,9 @@ function wesnoth.wml_actions.xp_mod(cfg)
 	})
 	unit.experience = unit.experience - cfg.cost
 
-	local speaker = string.format("%s the %s", tostring(unit.name),  tostring(wesnoth.unit_types[unit.type].name))
-	local message = string.format("I spent %s xp for %s!", cfg.cost,  tostring(cfg.desc))
+	-- TRANSLATORS: Used to display a unit as "<unit name> the <unit type>". Example: "Tabryn the Marshal".
+	local speaker = string.format(_("%s the %s"), tostring(unit.name),  tostring(wesnoth.unit_types[unit.type].name))
+	local message = string.format(_("I spent %s xp for %s!"), cfg.cost,  tostring(cfg.desc))
 	wesnoth.message(speaker, message)
 
 	local floating_message = string.format("<span color='#BCB088'>%s</span>",  tostring(cfg.desc))
@@ -122,6 +126,7 @@ end
         {VARIABLE Rav_XP_move_amount 1}
         {VARIABLE Rav_XP_damage_amount 1}
         {VARIABLE Rav_XP_strike_amount 1}
+        {VARIABLE XP_mod_version {XP_MOD_VERSION}}
         [if]
             [variable]
                 name=Rav_XP_hp_cost
@@ -201,28 +206,30 @@ Default settings assumed."
         [/if]
         [lua]
             code = <<
+            local _ = wesnoth.textdomain "wesnoth-XP_Modification"
+            local current_version = wesnoth.get_variable "XP_mod_version"
 			local hp = wesnoth.get_variable "Rav_XP_hp_enabled"
 			local mp = wesnoth.get_variable "Rav_XP_move_enabled"
 			local dmg = wesnoth.get_variable "Rav_XP_damage_enabled"
 			local str = wesnoth.get_variable "Rav_XP_strike_enabled"
 			local amla_only = wesnoth.get_variable "Rav_XP_amla_only"
 			local settings = ""
-			if hp then settings = settings .. "Hitpoints cost: " .. wesnoth.get_variable "Rav_XP_hp_cost" .. " | " else end
-			if mp then settings = settings .. "Movement cost: " .. wesnoth.get_variable "Rav_XP_move_cost" .. " | " else end
-			if dmg then settings = settings .. "Damage cost: " .. wesnoth.get_variable "Rav_XP_damage_cost" .. " | " else end
-			if str then settings = settings .. "Strikes cost: " .. wesnoth.get_variable "Rav_XP_strike_cost" .. " | " else end
+			if hp then settings = settings .. _("Hitpoints cost: ") .. wesnoth.get_variable "Rav_XP_hp_cost" .. " | " else end
+			if mp then settings = settings .. _("Movement cost: ") .. wesnoth.get_variable "Rav_XP_move_cost" .. " | " else end
+			if dmg then settings = settings .. _("Damage cost: ") .. wesnoth.get_variable "Rav_XP_damage_cost" .. " | " else end
+			if str then settings = settings .. _("Strikes cost: ") .. wesnoth.get_variable "Rav_XP_strike_cost" .. " | " else end
 			if settings == "" then else
 				if amla_only then
 					wesnoth.set_variable("Rav_XP_amla_only", 1)
-					settings = settings .. "AMLA only: yes"
+					settings = settings .. _("AMLA only: yes")
 				else
 					wesnoth.set_variable("Rav_XP_amla_only", 0)
-					settings = settings .. "AMLA only: no"
+					settings = settings .. _("AMLA only: no")
 				end
-				wesnoth.message("XP Mod version 2.4.4", settings)
+				wesnoth.message(_("XP Mod version ") .. current_version, settings)
 			end
 			>>
         [/lua]
-        {CLEAR_VARIABLE Rav_XP_strike_enabled,Rav_XP_damage_enabled,Rav_XP_move_enabled,Rav_XP_hp_enabled,Rav_XP_drainer_penalty}
+        {CLEAR_VARIABLE Rav_XP_strike_enabled,Rav_XP_damage_enabled,Rav_XP_move_enabled,Rav_XP_hp_enabled,Rav_XP_drainer_penalty,XP_mod_version}
     [/event]
 [/modification]

--- a/mods/xp_mod_beta.cfg
+++ b/mods/xp_mod_beta.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth-XP_Modification
+
 [modification]
     id=Rav_XP_Mod_Beta
     name=_"XP Mod (Beta)"
@@ -9,7 +11,7 @@ When unit has multiple attacks with same name+type+range, upgrade takes lowest v
 
 Attacks that are not from unit type might get upgraded, but not tested.
 
-version 2.4.4 by Ravana"
+version "+{XP_MOD_VERSION}+_" by Ravana"
     require_modification=no
     type=hybrid
     [options]
@@ -30,6 +32,7 @@ version 2.4.4 by Ravana"
         [lua]
             code=<<
 local T = wml.tag
+local _ = wesnoth.textdomain "wesnoth-XP_Modification"
 
 local function format_number(value)
 	if value > 0 then
@@ -198,14 +201,15 @@ function wesnoth.wml_actions.xp_mod_damage(cfg)
 		})
 		desc = desc .. " | " .. attack_description .. " (" .. format_number(proposed_damage - base_damage) .. ", " .. format_number(proposed_strikes - base_strikes) .. ")"
 	end
-	desc = desc .. " | Power modifer: +" .. tostring(power_percent) .. "%"
+	desc = desc .. " | " .. _("Power modifer: +") .. tostring(power_percent) .. "%"
 
 	unit:add_modification("object", object)
 
 	unit.experience = unit.experience - cfg.cost
 
-	local speaker = string.format("%s the %s", tostring(unit.name), tostring(wesnoth.unit_types[unit.type].name))
-	local message = string.format("I spent %s xp and now have %s!", cfg.cost, tostring(desc))
+	-- TRANSLATORS: Used to display a unit as "<unit name> the <unit type>". Example: "Tabryn the Marshal".
+	local speaker = string.format(_("%s the %s"), tostring(unit.name), tostring(wesnoth.unit_types[unit.type].name))
+	local message = string.format(_("I spent %s xp and now have %s!"), cfg.cost, tostring(desc))
 	wesnoth.message(speaker, message)
 
 	--local floating_message = string.format("<span color='#BCB088'>%s</span>", tostring(desc))
@@ -219,6 +223,7 @@ end
         name=turn 1
         #{VARIABLE Rav_XP_damage_cost_beta 0} # testing
         {VARIABLE Rav_XP_damage_percent 10}
+        {VARIABLE XP_mod_version {XP_MOD_VERSION}}
 
 		[set_menu_item]
 			id=xp_mod_exp_power
@@ -239,14 +244,17 @@ end
 		[/set_menu_item]
         [lua]
             code = <<
+            local _ = wesnoth.textdomain "wesnoth-XP_Modification"
+            local current_version = wesnoth.get_variable "XP_mod_version"
 			local settings = ""
-			settings = settings .. "Power cost: " .. wesnoth.get_variable "Rav_XP_damage_cost_beta" .. " | "
+			settings = settings .. _("Power cost: ") .. wesnoth.get_variable "Rav_XP_damage_cost_beta" .. " | "
 			if settings == "" then else
-				wesnoth.message("XP Mod version 2.4.4 (beta)", settings)
+				wesnoth.message(_("XP Mod version ") .. current_version .. " (beta)", settings)
 			end
 			>>
         [/lua]
 		# todo cant clear Rav_XP_damage_cost_beta Rav_XP_damage_percent
         #{CLEAR_VARIABLE Rav_XP_damage_cost_beta,Rav_XP_damage_percent}
+        {CLEAR_VARIABLE XP_mod_version}
     [/event]
 [/modification]

--- a/translations/wesnoth-XP_Modification/es.po
+++ b/translations/wesnoth-XP_Modification/es.po
@@ -1,0 +1,330 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wesnoth-XP_Modification\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-06-17 21:26\n"
+"PO-Revision-Date: 2026-06-17 21:45-0300\n"
+"Last-Translator: Sebastián Lecchini <sebas38760@gmail.com>\n"
+"Language-Team: es\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [set_menu_item], id=xp_mod_a
+#: XP_Modification/macros/xp.cfg:45
+msgid "+$Rav_XP_hp_amount hp: $Rav_XP_hp_cost xp"
+msgstr "+$Rav_XP_hp_amount PV: $Rav_XP_hp_cost PX"
+
+#. [set_menu_item], id=xp_mod_b
+#: XP_Modification/macros/xp.cfg:50
+msgid "+$Rav_XP_hp_amount hp: $Rav_XP_hp_cost_drainer xp"
+msgstr "+$Rav_XP_hp_amount PV: $Rav_XP_hp_cost_drainer PX"
+
+#. [set_menu_item], id=xp_mod_c
+#: XP_Modification/macros/xp.cfg:55
+msgid "+$Rav_XP_move_amount movement: $Rav_XP_move_cost xp"
+msgstr "+$Rav_XP_move_amount movimiento: $Rav_XP_move_cost PX"
+
+#. [set_menu_item], id=xp_mod_d
+#: XP_Modification/macros/xp.cfg:60
+msgid "+$Rav_XP_move_amount movement: $Rav_XP_move_cost_drainer xp"
+msgstr "+$Rav_XP_move_amount movimiento: $Rav_XP_move_cost_drainer PX"
+
+#. [set_menu_item], id=xp_mod_e
+#: XP_Modification/macros/xp.cfg:65
+msgid "+$Rav_XP_damage_amount damage: $Rav_XP_damage_cost xp"
+msgstr "+$Rav_XP_damage_amount daño: $Rav_XP_damage_cost PX"
+
+#. [set_menu_item], id=xp_mod_f
+#: XP_Modification/macros/xp.cfg:70
+msgid "+$Rav_XP_damage_amount damage: $Rav_XP_damage_cost_drainer xp"
+msgstr "+$Rav_XP_damage_amount daño: $Rav_XP_damage_cost_drainer PX"
+
+#. [set_menu_item], id=xp_mod_g
+#: XP_Modification/macros/xp.cfg:75
+msgid "+$Rav_XP_strike_amount strike: $Rav_XP_strike_cost xp"
+msgstr "+$Rav_XP_strike_amount ataque: $Rav_XP_strike_cost PX"
+
+#. [set_menu_item], id=xp_mod_h
+#: XP_Modification/macros/xp.cfg:80
+msgid "+$Rav_XP_strike_amount strike: $Rav_XP_strike_cost_drainer xp"
+msgstr "+$Rav_XP_strike_amount ataque: $Rav_XP_strike_cost_drainer PX"
+
+#. [modification], id=Rav_XP_Mod
+#: XP_Modification/mods/xp_mod.cfg:5
+msgid "XP Mod"
+msgstr "XP Mod"
+
+#. [modification], id=Rav_XP_Mod
+#: XP_Modification/mods/xp_mod.cfg:6
+msgid ""
+"Spend XP to upgrade units damage/strikes/health/movement.\n"
+"\n"
+"version "
+msgstr ""
+"Gasta PX para mejorar el daño/ataques/salud/movimiento de las unidades.\n"
+"\n"
+"versión "
+
+#. [modification], id=Rav_XP_Mod
+#: XP_Modification/mods/xp_mod.cfg:8
+msgid ""
+" by Ravana - based on work by vn971, Dovolente, itota and Nosmos\n"
+"\n"
+"Units with drain ability have higher upgrade cost"
+msgstr ""
+" por Ravana - basado en el trabajo de vn971, Dovolente, itota y Nosmos\n"
+"\n"
+"Las unidades con la habilidad de drenaje tienen un coste de mejora más alto"
+
+#. [checkbox], id=Rav_XP_amla_only
+#: XP_Modification/mods/xp_mod.cfg:17
+msgid "AMLA only"
+msgstr "Solo tras máximo nivel"
+
+#. [checkbox], id=Rav_XP_amla_only
+#: XP_Modification/mods/xp_mod.cfg:18
+msgid "Allow upgrades only on units that reached their max level"
+msgstr "Permitir mejoras solo en unidades que han alcanzado su nivel máximo"
+
+#. [checkbox], id=Rav_XP_hp_enabled
+#: XP_Modification/mods/xp_mod.cfg:23
+msgid "HP enabled"
+msgstr "PV activados"
+
+#. [checkbox], id=Rav_XP_hp_enabled
+#: XP_Modification/mods/xp_mod.cfg:24
+msgid "Hitpoints upgrades on/off"
+msgstr "Mejoras de puntos de vida activadas/desactivadas"
+
+#. [checkbox], id=Rav_XP_move_enabled
+#: XP_Modification/mods/xp_mod.cfg:29
+msgid "MP enabled"
+msgstr "Movimiento activado"
+
+#. [checkbox], id=Rav_XP_move_enabled
+#: XP_Modification/mods/xp_mod.cfg:30
+msgid "Movement upgrades on/off"
+msgstr "Mejoras de movimiento activadas/desactivadas"
+
+#. [checkbox], id=Rav_XP_damage_enabled
+#: XP_Modification/mods/xp_mod.cfg:35
+msgid "DMG enabled"
+msgstr "Daño activado"
+
+#. [checkbox], id=Rav_XP_damage_enabled
+#: XP_Modification/mods/xp_mod.cfg:36
+msgid "Damage upgrades on/off"
+msgstr "Mejoras de daño activadas/desactivadas"
+
+#. [checkbox], id=Rav_XP_strike_enabled
+#: XP_Modification/mods/xp_mod.cfg:41
+msgid "Strikes enabled"
+msgstr "Ataques activados"
+
+#. [checkbox], id=Rav_XP_strike_enabled
+#: XP_Modification/mods/xp_mod.cfg:42
+msgid "Strikes upgrades on/off"
+msgstr "Mejoras de ataques activadas/desactivadas"
+
+#. [slider], id=Rav_XP_hp_cost
+#: XP_Modification/mods/xp_mod.cfg:50
+msgid "HP cost"
+msgstr "Coste de PV"
+
+#. [slider], id=Rav_XP_hp_cost
+#: XP_Modification/mods/xp_mod.cfg:51
+msgid "XP required to upgrade hitpoints"
+msgstr "PX requeridos para mejorar los puntos de vida"
+
+#. [slider], id=Rav_XP_move_cost
+#: XP_Modification/mods/xp_mod.cfg:59
+msgid "MP cost"
+msgstr "Coste de movimiento"
+
+#. [slider], id=Rav_XP_move_cost
+#: XP_Modification/mods/xp_mod.cfg:60
+msgid "XP required to upgrade movement"
+msgstr "PX requeridos para mejorar el movimiento"
+
+#. [slider], id=Rav_XP_damage_cost
+#. [slider], id=Rav_XP_damage_cost_beta
+#: XP_Modification/mods/xp_mod.cfg:68 XP_Modification/mods/xp_mod_beta.cfg:24
+msgid "DMG cost"
+msgstr "Coste de daño"
+
+#. [slider], id=Rav_XP_damage_cost
+#: XP_Modification/mods/xp_mod.cfg:69
+msgid "XP required to upgrade damage"
+msgstr "PX requeridos para mejorar el daño"
+
+#. [slider], id=Rav_XP_strike_cost
+#: XP_Modification/mods/xp_mod.cfg:77
+msgid "Strike cost"
+msgstr "Coste de ataques"
+
+#. [slider], id=Rav_XP_strike_cost
+#: XP_Modification/mods/xp_mod.cfg:78
+msgid "XP required to upgrade strikes"
+msgstr "PX requeridos para mejorar los ataques"
+
+#. [slider], id=Rav_XP_drainer_penalty
+#: XP_Modification/mods/xp_mod.cfg:86
+msgid "Drainer penalty %"
+msgstr "Penalización de drenadores %"
+
+#. [slider], id=Rav_XP_drainer_penalty
+#: XP_Modification/mods/xp_mod.cfg:87
+msgid "XP cost penalty for drainers, in percent"
+msgstr "Penalización de coste de PX para drenadores, en porcentaje"
+
+#. TRANSLATORS: Used to display a unit as "<unit name> the <unit type>". Example: "Tabryn the Marshal".
+#. [lua]
+#. [4]
+#: XP_Modification/mods/xp_mod.cfg:112 XP_Modification/mods/xp_mod_beta.cfg:211
+msgid "%s the %s"
+msgstr "%s el %s"
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:113
+msgid "I spent %s xp for %s!"
+msgstr "¡Gasté %s PX por %s!"
+
+#. [chat]
+#: XP_Modification/mods/xp_mod.cfg:137
+msgid "XP Modification"
+msgstr "XP Mod"
+
+#. [chat]
+#: XP_Modification/mods/xp_mod.cfg:138
+msgid ""
+"WARNING\n"
+"\n"
+"Settings not found. Expected cause is bug #23512. Fix is enabling Advanced "
+"Settings->Level options in campaign menu.\n"
+"\n"
+"Default settings assumed."
+msgstr ""
+"ADVERTENCIA\n"
+"\n"
+"No se encontraron los ajustes. La causa probable es el error #23512. La "
+"solución es habilitar Ajustes avanzados->Opciones de nivel en el menú de la "
+"campaña.\n"
+"\n"
+"Se asumirán los ajustes predeterminados."
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:217
+msgid "Hitpoints cost: "
+msgstr "Costo de PV: "
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:218
+msgid "Movement cost: "
+msgstr "Costo de movimiento: "
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:219
+msgid "Damage cost: "
+msgstr "Costo del daño: "
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:220
+msgid "Strikes cost: "
+msgstr "Costo de ataques: "
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:224
+msgid "AMLA only: yes"
+msgstr "Solo tras máximo nivel: sí"
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:227
+msgid "AMLA only: no"
+msgstr "Solo tras máximo nivel: no"
+
+#. [lua]
+#: XP_Modification/mods/xp_mod.cfg:229 XP_Modification/mods/xp_mod_beta.cfg:252
+msgid "XP Mod version "
+msgstr "XP Mod versión "
+
+#. [modification], id=Rav_XP_Mod_Beta
+#: XP_Modification/mods/xp_mod_beta.cfg:5
+msgid "XP Mod (Beta)"
+msgstr "XP Mod (Beta)"
+
+#. [modification], id=Rav_XP_Mod_Beta
+#: XP_Modification/mods/xp_mod_beta.cfg:6
+msgid ""
+"Experiment where damage and strike upgrades are automatically distributed "
+"and upgrade amount is 10% of base value instead of constant. Distribution "
+"aims to stay close to original damage per strike, but staying between 2 and "
+"5 damage per strike. May be enabled together with regular XP Mod, but "
+"disable strike and damage upgrades there then or amounts can be unexpected. "
+"Drain and amla-only logic is not fully implemented yet.\n"
+"\n"
+"When base damage or strike is 1, then upgrade is allowed to reduce the other "
+"value by 25% to achieve more evenly distributed damage and strikes.\n"
+"\n"
+"When unit has multiple attacks with same name+type+range, upgrade takes "
+"lowest values from all of them. So 40-1 and 4-10 with same name are 4-1 for "
+"upgrade purpose.\n"
+"\n"
+"Attacks that are not from unit type might get upgraded, but not tested.\n"
+"\n"
+"version "
+msgstr ""
+"Experimento donde las mejoras de daño y golpes se distribuyen "
+"automáticamente y la cantidad de mejora es el 10% del valor base en lugar de "
+"ser constante. La distribución intenta mantenerse cerca del daño original "
+"por golpe, pero dentro de un rango de entre 2 y 5 de daño por golpe. Puede "
+"activarse junto con el XP Mod normal, pero entonces desactiva allí las "
+"mejoras de golpes y daño o los valores podrían resultar inesperados. La "
+"lógica de drenaje y de solo AMLA aún no está implementada por completo.\n"
+"\n"
+"Cuando el daño base o la cantidad de golpes es 1, la mejora puede reducir el "
+"otro valor en un 25% para lograr una distribución más equilibrada entre daño "
+"y golpes.\n"
+"\n"
+"Cuando una unidad tiene varios ataques con el mismo nombre+tipo+alcance, la "
+"mejora toma los valores más bajos de todos ellos. Así, 40-1 y 4-10 con el "
+"mismo nombre se consideran 4-1 para fines de mejora.\n"
+"\n"
+"Los ataques que no provienen del tipo de unidad podrían mejorarse, pero no "
+"han sido probados.\n"
+"\n"
+"versión "
+
+#. [modification], id=Rav_XP_Mod_Beta
+#: XP_Modification/mods/xp_mod_beta.cfg:14
+msgid " by Ravana"
+msgstr " por Ravana"
+
+#. [slider], id=Rav_XP_damage_cost_beta
+#: XP_Modification/mods/xp_mod_beta.cfg:25
+msgid "XP required to upgrade total power"
+msgstr "PX requeridos para mejorar el poder total"
+
+#. [4]
+#: XP_Modification/mods/xp_mod_beta.cfg:204
+msgid "Power modifer: +"
+msgstr "Modificador de poder: +"
+
+#. [4]
+#: XP_Modification/mods/xp_mod_beta.cfg:212
+msgid "I spent %s xp and now have %s!"
+msgstr "¡Gasté %s PX y ahora tengo %s!"
+
+#. [set_menu_item], id=xp_mod_exp_power
+#: XP_Modification/mods/xp_mod_beta.cfg:230
+msgid "+$Rav_XP_damage_percent|% base damage: $Rav_XP_damage_cost_beta xp"
+msgstr "+$Rav_XP_damage_percent|% daño base: $Rav_XP_damage_cost_beta PX"
+
+#. [lua]
+#: XP_Modification/mods/xp_mod_beta.cfg:250
+msgid "Power cost: "
+msgstr "Costo de energía: "
+
+#~ msgid "XP Mod version 2.4.3 (beta)"
+#~ msgstr "XP Mod version 2.4.3 (beta)"


### PR DESCRIPTION
* Marked strings as translatable.
* Added a macro containing the current mod version number, so it only needs to be updated in one place. In Lua environments, the version number is exposed through a variable created in the corresponding file's turn 1 event and cleared at the end of that event.
* Updated the Spanish translation.